### PR TITLE
MINOR - Add PR Labelling Workflow

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,4 @@
+minor: ['MINOR/*', 'minor/*']
+major: ['MAJOR/*', 'major/*' ]
+patch: [ 'PATCH/*', 'patch/*' ]
+dependencies: [ 'DEPENDENCY/*', 'dependency/*', 'dependabot/*']

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,8 +17,6 @@ on:
 permissions:
   # Used for Dependabot Pull Requests. We need to ensure that builds pass when we update dependencies automatically. This can be done by granting contents: write
   # Letting them create releases.
-
-  # another test comment
   contents: write
 
 jobs:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,19 @@
+name: PR Labeler
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  pr-labeler:
+    permissions:
+      contents: read # for TimonVS/pr-labeler-action to read config file
+      pull-requests: write # for TimonVS/pr-labeler-action to add labels in PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/pr-labeler.yml # optional, .github/pr-labeler.yml is the default value


### PR DESCRIPTION
- No unit tests needed here
- Add a PR labelling workflow, should automatically label workflows in PRs depending on branch naming convention
  - So long as branch naming conventions are followed, this should run.