### PR TITLE
PATCH - Fix Member Caching Policy

### DIFF
--- a/api/src/test/java/me/longbow122/api/controller/FormControllerTest.java
+++ b/api/src/test/java/me/longbow122/api/controller/FormControllerTest.java
@@ -29,7 +29,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(FormController.class)
 @OverrideAutoConfiguration(enabled = true)
 @ActiveProfiles(profiles = "test")
-@MockBeans({@MockBean(DiscordConfigurationProperties.class)})
+@MockBeans({
+	@MockBean(DiscordConfigurationProperties.class)
+})
 class FormControllerTest {
 
 	/*

--- a/bot/src/main/java/me/longbow122/bot/configuration/DiscordConfigurer.java
+++ b/bot/src/main/java/me/longbow122/bot/configuration/DiscordConfigurer.java
@@ -16,6 +16,7 @@ import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.requests.restaction.CommandListUpdateAction;
+import net.dv8tion.jda.api.utils.MemberCachePolicy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -46,6 +47,7 @@ public class DiscordConfigurer {
         JDA jdaBuild = JDABuilder
                 .createDefault(discordConfigurationProperties.botToken())
                 .enableIntents(List.of(GatewayIntent.GUILD_MEMBERS))
+                .setMemberCachePolicy(MemberCachePolicy.ALL)
                 .setActivity(Activity.customStatus("Use /form for help!"))
                 .addEventListeners(new SlashCopypastaCommandListener(copypastaService, discordConfigurationProperties))
                 .addEventListeners(new CopypastaAutocompleteListener(copypastaService))

--- a/bot/src/main/java/me/longbow122/bot/listener/SlashCopypastaCommandListener.java
+++ b/bot/src/main/java/me/longbow122/bot/listener/SlashCopypastaCommandListener.java
@@ -43,6 +43,7 @@ public class SlashCopypastaCommandListener extends ListenerAdapter {
 			event.reply(copypastaService.findCopypastaByName(event.getName()).get().getMessage()).setEphemeral(false).queue();
 			return;
 		}
+		//* Worth noting that we are only checking cached members here, so need to ensure that members are cached properly when checking.
 		Member user = event.getGuild().getMemberById(event.getUser().getIdLong());
 		if (user == null) {
 			event.reply("SOMETHING HAS GONE WRONG WITH COPYPASTA COMMANDS. WE COULD NOT FIND A USER!").setEphemeral(false).queue();

--- a/bot/src/main/java/me/longbow122/bot/service/FormService.java
+++ b/bot/src/main/java/me/longbow122/bot/service/FormService.java
@@ -44,6 +44,7 @@ public class FormService {
 		}
 		//* Thanks to Discord and globally unique usernames, this should ideally be of size 1 every time.
 		//* As such, we always get the first one. We don't have access to user IDs in this case, not without discord logins.
+		//* Worth noting that we are only checking cached members here, so need to ensure that we are caching members properly.
 		List<Member> found = guild.getMembersByName(form.poster(), false);
 		if (found.isEmpty()) {
 			throw new UserNotFoundException("Member not found! They must not be in the discord server!");


### PR DESCRIPTION
**Are your changes currently passing unit tests?**
- Changes currently passing unit tests

Have you had to add any new tests for your changes: **NO**

**Describe changes below:**
- Changed MemberCachePolicy to cache all server members, only removing members when they leave.
- Added explanative comments noting where we are making use of member caching.
- Changes tested and confirmed as working.